### PR TITLE
Added in enum for socket events.

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,37 @@
+use std::sync::Arc;
+
+use connection::Connection;
+use net::connection::Quality;
+
+/// Events that are generated in response to a change in state of the connected client
+pub enum ConnectionEvent {
+    /// A new client connects. Clients are uniquely identified by the ip:port combination at this layer.
+    Connected{ conn: Arc<Connection> },
+    /// A client disconnects. This can be generated from the server-side intentionally disconnecting a client,
+    /// or it could be from the client disconnecting.
+    Disconnected{ conn: Arc<Connection> },
+    /// This is generated if the server has not seen traffic from a client for a configurable amount of time.
+    TimedOut{ conn: Arc<Connection> },
+    /// This is generated when there is a change in the connection quality of a client.
+    QualityChange{ conn: Arc<Connection>, from: Quality, to: Quality },
+}
+
+#[cfg(test)]
+mod test {
+    use super::ConnectionEvent;
+    use connection::Connection;
+    use std::sync::Arc;
+    use std::net::ToSocketAddrs;
+
+    static TEST_HOST_IP: &'static str = "127.0.0.1";
+    static TEST_PORT: &'static str = "20000";
+
+    #[test]
+    fn test_create_event() {
+        let addr = format!("{}:{}", TEST_HOST_IP, TEST_PORT).to_socket_addrs();
+        let mut addr = addr.unwrap();
+        let test_conn = Arc::new(Connection::new(addr.next().unwrap()));
+        let _ = ConnectionEvent::Connected{conn: test_conn};
+    }
+
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod packet;
 pub mod amethyst_error;
 pub mod connection;
 pub mod server;
+pub mod events;
 
 pub use net::udp::UdpSocket;
 use packet::{Packet, RawPacket};

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -25,7 +25,7 @@ impl Connection {
 /// We should use this for handling Congestion Avoidance so that when the network of the client is bad we do not flood the router with small packets.
 ///
 /// When network conditions are `Good` we send 30 packets per-second, and when network conditions are `Bad` we drop to 10 packets per-second.
-pub enum ConnectionQuality {
+pub enum Quality {
     Good,
     Bad,
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,10 +1,10 @@
-mod connection;
 mod external_ack;
 mod local_ack;
 mod socket_state;
+pub mod connection;
 pub mod udp;
 
-pub use self::connection::{Connection, ConnectionQuality};
+pub use self::connection::{Connection, Quality};
 use self::external_ack::ExternalAcks;
 use self::local_ack::LocalAckRecord;
 use self::socket_state::SocketState;


### PR DESCRIPTION
@LucioFranco @TimonPost I started on events. These will be the things we bubble up to the client. I noticed that we have a connection in the `net` module, and then a top-level Connection struct; we should clearly differentiate these in terms of responsibilities, and probably names.