### PR TITLE
WIP: Channel implementation | DO NOT MERGE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 .idea/
 **/*.rs.bk
 Cargo.lock
+*.iml

--- a/src/channel/channel.rs
+++ b/src/channel/channel.rs
@@ -1,0 +1,99 @@
+use std::io;
+use std::net::{SocketAddr, UdpSocket as UnreliableUdp};
+
+use super::{Channel, ChannelType, ReliableUnorderedChannel, UnreliableChannel};
+use packet::Packet;
+use net::UdpSocket as ReliableUdp;
+
+type ChannelIml = Box<Channel + Send + Sync>;
+
+pub struct CommunicationChannel
+{
+    channel: ChannelIml
+}
+
+impl CommunicationChannel
+{
+    /// Create new Communication Channel from the given ChannelType and sets the listener on the given host.
+    pub fn new(channel_type: ChannelType, host: SocketAddr) -> Self
+    {
+        let channel: ChannelIml;
+
+        match channel_type
+        {
+            ChannelType::ReliableUnordered =>
+            {
+                let udp_socket = ReliableUdp::bind(host).unwrap();
+                channel = Box::from(ReliableUnorderedChannel::new(udp_socket)) as ChannelIml
+            },
+            ChannelType::Unreliable =>
+            {
+                let udp_socket = UnreliableUdp::bind(host).unwrap();
+                channel = Box::from(UnreliableChannel::new(udp_socket)) as ChannelIml;
+            },
+        };
+
+        CommunicationChannel { channel }
+    }
+
+    /// Send information to the given endpoint.
+    pub fn send(&mut self, addr: SocketAddr, payload: &[u8])  -> io::Result<usize> {
+        self.channel.send(addr, payload)
+    }
+
+    /// Receive data from the channel and return the packet if there is result.
+    pub fn recv(&mut self) -> io::Result<Option<Packet>>{
+        self.channel.recv()
+    }
+}
+
+// TODO: These tests may fail but if runned seperately they succeed. Maybe because of receive can not receive because there is not data jet to read.
+// TODO: So we need to implement something to make channel able to be a blocking channel or non blocking.
+mod tests {
+    use std::net::{SocketAddr, IpAddr};
+    use std::str::{self, FromStr};
+    use std::io;
+
+    use packet::Packet;
+    use channel::{CommunicationChannel, ChannelType};
+
+    #[test]
+    fn send_packet_reliable_unordered_channel()
+    {
+        let ip_sender = SocketAddr::new(IpAddr::from_str("127.0.0.1").unwrap(), 12345);
+        let ip_receiver = SocketAddr::new(IpAddr::from_str("127.0.0.1").unwrap(), 12346);
+
+        let mut channel_sender = CommunicationChannel::new(ChannelType::ReliableUnordered, ip_sender);
+        let mut channel_receiver = CommunicationChannel::new(ChannelType::ReliableUnordered, ip_receiver);
+
+        let packet = channel_receiver.recv();
+        channel_sender.send(ip_receiver, &[123]);
+
+        let parsed = packet.unwrap().unwrap();
+
+        assert_eq!(parsed.payload(), &[123]);
+    }
+
+    #[test]
+    fn send_packet_unreliable_channel()
+    {
+        use std::{thread, time};
+
+        let ip_sender = SocketAddr::new(IpAddr::from_str("127.0.0.1").unwrap(), 12345);
+        let ip_receiver = SocketAddr::new(IpAddr::from_str("127.0.0.1").unwrap(), 12346);
+
+        let mut channel_sender = CommunicationChannel::new(ChannelType::Unreliable, ip_sender);
+        let mut channel_receiver = CommunicationChannel::new(ChannelType::Unreliable, ip_receiver);
+
+        thread::spawn(move || {
+            thread::sleep(time::Duration::from_millis(20));
+            let packet: Result<Option<Packet>, io::Error> = channel_receiver.recv();
+
+            let parsed: Packet = packet.unwrap().unwrap();
+
+            assert_eq!(parsed.payload(), &[123]);
+        });
+
+        channel_sender.send(ip_receiver, &[123]);
+    }
+}

--- a/src/channel/channel.rs
+++ b/src/channel/channel.rs
@@ -5,7 +5,7 @@ use super::{Channel, ChannelType, ReliableUnorderedChannel, UnreliableChannel};
 use packet::Packet;
 use net::UdpSocket as ReliableUdp;
 
-type ChannelIml = Box<Channel + Send + Sync>;
+type ChannelImpl = Box<Channel + Send + Sync>;
 
 pub struct CommunicationChannel
 {

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -1,0 +1,58 @@
+use std::net::{SocketAddr, IpAddr};
+use std::io;
+use std::str::{self, FromStr};
+
+mod reliable_unordered;
+//mod reliable;
+mod unreliable;
+mod channel;
+
+pub use self::reliable_unordered::ReliableUnorderedChannel;
+pub use self::unreliable::UnreliableChannel;
+pub use self::channel::CommunicationChannel;
+
+use packet::Packet;
+
+pub enum ChannelType
+{
+
+    /// This type means:
+    ///
+    ///  1. Reliable.
+    ///  2. No guarantee for delivery.
+    ///  3. No guarantee for order.
+    ///  4. Able to get dropped packets from the channel (udp with option to get dropped packets).
+    ///
+    /// Basically UDP but with a way to retrieve dropped packets.
+    ReliableUnordered,
+    /// This type means:
+    ///
+    /// 1. Unreliable
+   ///  2. No guarantee for delivery.
+   ///  3. No guarantee for order.
+   ///  4. No way of getting dropped packet
+   ///
+   /// Basically just bare UDP
+    Unreliable,
+
+    // TODO: Reliable, guarantee for delivery (just bare tcp)
+    // Reliable,
+    // Todo: Unreliable, this represents an channel that will deliver everything in order. If packets do not arrive they will be stored and you can decide what to do with them.
+    // Sequenced,
+}
+
+/// This trait provides an interface for an chanel that could be used to communicate over.
+pub trait Channel
+{
+    /// Send information to the given endpoint.
+    fn send(&mut self, addr: SocketAddr, payload: &[u8])  -> io::Result<usize>;
+    /// Receive data from the channel and return the packet if there is result.
+    fn recv(&mut self) ->  io::Result<Option<Packet>>;
+}
+
+
+
+
+
+
+

--- a/src/channel/reliable_unordered.rs
+++ b/src/channel/reliable_unordered.rs
@@ -1,0 +1,37 @@
+use std::io;
+use std::net::SocketAddr;
+
+use net::UdpSocket;
+use packet::{RawPacket, Packet};
+
+use super::Channel;
+
+/// This channel receives data that has no guarantee that it is in ordered but that has control over dropped packets if there are any.
+///
+///  1. Reliable,
+///  2. No guarantee for delivery
+///  3. No guarantee that it is in order
+///  4. Able to get dropped packets from the channel (udp with option to get dropped packets).
+pub struct ReliableUnorderedChannel
+{
+    socket: UdpSocket
+}
+
+impl ReliableUnorderedChannel
+{
+    pub fn new(socket: UdpSocket) -> Self
+    {
+        ReliableUnorderedChannel { socket }
+    }
+}
+
+impl Channel for ReliableUnorderedChannel
+{
+    fn send(&mut self, addr: SocketAddr, payload: &[u8]) -> io::Result<usize> {
+        self.socket.send(Packet::new(addr, Vec::from(payload)))
+    }
+
+    fn recv(&mut self) -> io::Result<Option<Packet>> {
+        self.socket.recv()
+    }
+}

--- a/src/channel/unreliable.rs
+++ b/src/channel/unreliable.rs
@@ -1,0 +1,45 @@
+use std::net::{UdpSocket, SocketAddr};
+use std::io;
+
+use packet::{RawPacket, Packet};
+use super::Channel;
+
+use net::constants::UDP_BUFFER_SIZE;
+
+/// This channel receives data that has no guarantee that it is in ordered but that has control over dropped packets if there are any.
+///
+///  1. Reliable,
+///  2. No guarantee for delivery
+///  3. No guarantee that it is in order
+///  4. Able to get dropped packets from the channel (udp with option to get dropped packets).
+pub struct UnreliableChannel
+{
+    socket: UdpSocket,
+    recv_buffer: [u8; UDP_BUFFER_SIZE],
+}
+
+impl UnreliableChannel
+{
+    pub fn new(socket: UdpSocket) -> Self
+    {
+        socket.set_nonblocking(true);
+        UnreliableChannel { socket, recv_buffer: [0; UDP_BUFFER_SIZE] }
+    }
+}
+
+impl Channel for UnreliableChannel
+{
+    fn send(&mut self, addr: SocketAddr, payload: &[u8]) -> io::Result<usize> {
+        self.socket.send(payload)
+    }
+
+    fn recv(&mut self) ->  io::Result<Option<Packet>> {
+        let (len, _addr) = self.socket.recv_from(&mut self.recv_buffer)?;
+
+        if len > 0 {
+            Ok(Some(Packet::new(_addr, self.recv_buffer[0..len].to_vec())))
+        }else {
+            Ok(None)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate serde_derive;
 
 mod net;
 mod packet;
+mod channel;
 
 pub use net::UdpSocket;
 use packet::{Packet, RawPacket};

--- a/src/net/constants.rs
+++ b/src/net/constants.rs
@@ -1,0 +1,1 @@
+pub const UDP_BUFFER_SIZE: usize = 1024;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -3,6 +3,7 @@ mod external_ack;
 mod local_ack;
 mod socket_state;
 mod udp;
+pub mod constants;
 
 pub use self::connection::{Connection, ConnectionQuality};
 use self::external_ack::ExternalAcks;

--- a/src/net/socket_state.rs
+++ b/src/net/socket_state.rs
@@ -52,6 +52,7 @@ impl SocketState {
         let dropped_packets = connection
             .waiting_packets
             .ack(packet.ack_seq, packet.ack_field);
+
         connection.dropped_packets = dropped_packets.into_iter().map(|(_, p)| p).collect();
 
         Packet {

--- a/timon.iml
+++ b/timon.iml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="NewModuleRootManager">
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/timon.iml
+++ b/timon.iml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="NewModuleRootManager">
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>


### PR DESCRIPTION
This PR is about providing an abstraction on top of different sockets. 

I thought a nice word to describe these abstractions would be "Channels".

Like we have :

- ReliableChannel
- UnreliableChannel
- ReliableOrderedChannel
- ReliableUnorderedChannel

They all implement `Channel` trait. Witch have to functions :

```
trait Channel
{
    fn send(&self, addr: SocketAddr, payload: &[u8]);
    fn recv(&self) -> Packet;
}
```

Then finally one struct that takes in a type of channel decides the right implementation to use for the enum type. Currently, this is called `CommunicationChannel`.

_For the user it will look like:_ 

```
        let ip_sender = SocketAddr::new(IpAddr::from_str("127.0.0.1").unwrap(), 12345);
        let ip_receiver = SocketAddr::new(IpAddr::from_str("127.0.0.1").unwrap(), 12346);

        let mut channel_sender = CommunicationChannel::new(ChannelType::ReliableUnordered, ip_sender);
        let mut channel_receiver = CommunicationChannel::new(ChannelType::ReliableUnordered, ip_receiver);

        let packet = channel_receiver.recv();
        channel_sender.send(ip_receiver, &[123]);

        let parsed = packet.unwrap().unwrap();
        assert_eq!(parsed.payload(), &[123]);
```

_The user only has to pass a ChannelType like to `CommunicationChannel`:_

```
pub enum ChannelType
{
    /// This type means:
    ///
    ///  1. Reliable.
    ///  2. No guarantee for delivery.
    ///  3. No guarantee for order.
    ///  4. Able to get dropped packets from the channel (udp with option to get dropped packets).
    ///
    /// Basically UDP but with a way to retrieve dropped packets.
    ReliableUnordered,
    /// This type means:
    ///
    /// 1. Unreliable
   ///  2. No guarantee for delivery.
   ///  3. No guarantee for order.
   ///  4. No way of getting dropped packet
   ///
   /// Basically just bare UDP
    Unreliable,
    
    // TODO: Reliable, guarantee for delivery (just bare tcp)
    // Reliable,
    // Todo: Unreliable, this represents an channel that will deliver everything in order. If packets do not arrive they will be stored and you can decide what to do with them.
    // Sequenced,
}
```

